### PR TITLE
docs: update default faithfulness instruction in rage.results module

### DIFF
--- a/rage/metrics/generate_based/answer_faithfulness.py
+++ b/rage/metrics/generate_based/answer_faithfulness.py
@@ -8,7 +8,7 @@ from rage.models import RageClassifier, RageClassifierKwargs
 from rage.results import FaithfulnessResult
 
 default_faithfulness_instruction = (
-    "You are tasked to evaluate whether the generated answer is fully supported by the retrieved context."
+    "You are tasked to evaluate whether the key point in generated answer is supported by the retrieved context."
 )
 
 


### PR DESCRIPTION
The default faithfulness instruction in the `rage.results` module has been updated to clarify that the task is to evaluate whether the key point in the generated answer is supported by the retrieved context. This change provides a more accurate description of the evaluation task.