### PR TITLE
feat: add 'extra' field to RageCase model

### DIFF
--- a/rage/case.py
+++ b/rage/case.py
@@ -1,4 +1,4 @@
-from typing import Generic, List, TypeVar
+from typing import Any, Dict, Generic, List, TypeVar
 
 from pydantic import BaseModel
 
@@ -11,7 +11,7 @@ class RageCase(BaseModel):
     answer: str = ""
     retrieved_contexts: List[str] = []
     generated_answer: str = ""
-
+    extra: Dict[str, Any] = {}
 
 class RageExample(BaseModel, Generic[T]):
     rage_case: RageCase


### PR DESCRIPTION
The 'extra' field is added to the RageCase model to allow for additional information to be included in the case. This can be useful for storing any extra data related to the case that may not fit into the existing fields.